### PR TITLE
Memory fix

### DIFF
--- a/example/activeDNS.chpl
+++ b/example/activeDNS.chpl
@@ -115,8 +115,8 @@ forall (ipRegexp, dnsRegexp) in zip(blacklistIPRegexp.broadcast, blacklistDNSNam
   ipRegexp = compile(blacklistDNSNamesRegex);
   dnsRegexp = compile(blacklistIPRegex);
 }
-var vPropMap = new PropertyMap(String);
-var ePropMap = new PropertyMap(String);
+var vPropMap = new PropertyMap(string);
+var ePropMap = new PropertyMap(string);
 var wq = new WorkQueue(string, 1024);
 var td = new TerminationDetector();
 var blacklistIPAddresses : domain(string);
@@ -190,7 +190,7 @@ proc searchBlacklist(graph, prefix) {
     }
   }
   forall v in graph.getVertices() with (in blacklistIPAddresses) {
-    var ip = graph.getProperty(v).toString();
+    var ip = graph.getProperty(v);
     if blacklistIPAddresses.contains(ip) {
       var f = open(outputDirectory +"/"+ prefix + "/" + ip,iomode.cw).writer();
       f.writeln("Blacklisted ip address ", ip);
@@ -227,7 +227,9 @@ proc searchBlacklist(graph, prefix) {
     } 
   } writeln("Finished searching for blacklisted IPs...");
   forall e in graph.getEdges() with (in blacklistDNSNames) {
-    var dnsName = graph.getProperty(e).toString();
+    chpl_task_yield();
+    var monsterEdge : bool;
+    var dnsName = graph.getProperty(e);
     var isBadDNS = dnsName.matches(blacklistDNSNamesRegexp.get());
     if blacklistDNSNames.contains(dnsName) || isBadDNS.size != 0 {
       var f = open(outputDirectory + prefix + "/" + dnsName, iomode.cw).writer();
@@ -235,32 +237,57 @@ proc searchBlacklist(graph, prefix) {
 
       // Print out its local neighbors...
       f.writeln("(" + prefix + ") Blacklisted DNS Name: ", dnsName);
+      var timer = new Timer();
+      var globalTimer = new Timer();
+      globalTimer.start();
       for s in 1..3 {
+        timer.start();
         f.writeln("\tLocal Neighborhood (s=", s, "):");
-        forall neighbor in graph.walk(e, s, isImmutable=true) {
+        var numInclusions : int;
+        forall neighbor in graph.walk(e, s, isImmutable=true) with (+ reduce numInclusions) {
           var str = "\t\t" + graph.getProperty(neighbor) + "\t";
           for n in graph.incidence(neighbor) {
             str += graph.getProperty(n) + ",";
           }
           f.writeln(str[..str.size - 1]);
           f.flush();
+          chpl_task_yield();
+          numInclusions += graph.degree(neighbor);
+        }
+        if numInclusions > 100000 {
+          writeln(dnsName, " is a monster edge for (s=", s, ") with ", numInclusions, " inclusions.");
+          monsterEdge = true;
         }
         f.flush();
+        timer.stop();
+        writeln("Neighbors of ", dnsName, " (s=", s, "): ", timer.elapsed());
+        timer.clear();
       }
+      globalTimer.stop();
+      writeln("Neighbors of ", dnsName, " in total: ", globalTimer.elapsed());
+      globalTimer.clear();
 
       // Print out its component
+      globalTimer.start();
       for s in 1..3 {
+        chpl_task_yield();
+        timer.start();
         f.writeln("\tComponent (s=", s, "):");
-        forall ee in edgeBFS(graph, e, s) {
+        forall ee in edgeBFS(graph, e, s, useMaximumParallelism=monsterEdge) {
           var eee = graph.toEdge(ee);
           var str = "\t\t" + graph.getProperty(eee) + "\t";
           for n in graph.incidence(eee) {
             str += graph.getProperty(n) + ",";
           }
           f.writeln(str[..str.size - 1]);
+          chpl_task_yield();
           f.flush();
         }
+        timer.stop();
+        writeln("Component of ", dnsName, " (s=", s, "): ", timer.elapsed());
       }
+      globalTimer.stop();
+      writeln("Component of ", dnsName, " in total: ", globalTimer.elapsed());
     }
   }
   writeln("Finished searching for blacklisted DNSs...");
@@ -297,8 +324,8 @@ wq.flush();
 forall fileName in doWorkLoop(wq, td) {
   for line in getLines(fileName) {
     var attrs = line.split(",");
-    var qname = new String(attrs[1].strip());
-    var rdata = new String(attrs[2].strip());
+    var qname = attrs[1].strip();
+    var rdata = attrs[2].strip();
 
     vPropMap.create(rdata, aggregated=true);
     ePropMap.create(qname, aggregated=true);
@@ -351,15 +378,15 @@ wq.flush();
 // Aggregate fetches to properties into another work queue; when we flush
 // each of the property maps, their individual PropertyHandle will be finished.
 // Also send the 'String' so that it can be reclaimed.
-var handleWQ = new WorkQueue((String, unmanaged PropertyHandle, String, unmanaged PropertyHandle), 64 * 1024);
+var handleWQ = new WorkQueue((unmanaged PropertyHandle, unmanaged PropertyHandle), 64 * 1024);
 var handleTD = new TerminationDetector();
 forall fileName in doWorkLoop(wq, td) {
   for line in getLines(fileName) {
     var attrs = line.split(",");
-    var qname = new String(attrs[1].strip());
-    var rdata = new String(attrs[2].strip());
+    var qname = attrs[1].strip();
+    var rdata = attrs[2].strip();
     handleTD.started(1);
-    handleWQ.addWork((rdata, vPropMap.getPropertyAsync(rdata), qname, ePropMap.getPropertyAsync(qname)));
+    handleWQ.addWork((vPropMap.getPropertyAsync(rdata), ePropMap.getPropertyAsync(qname)));
   }
   td.finished();
 }
@@ -368,12 +395,10 @@ ePropMap.flushGlobal();
 
 // Finally aggregate inclusions for the hypergraph.
 graph.startAggregation();
-forall (vStr, vHandle, eStr, eHandle) in doWorkLoop(handleWQ, handleTD) {
+forall (vHandle, eHandle) in doWorkLoop(handleWQ, handleTD) {
   graph.addInclusion(vHandle.get(), eHandle.get());
   delete vHandle;
   delete eHandle;
-  vStr.destroy();
-  eStr.destroy();
   handleTD.finished(1);
 }
 graph.stopAggregation();

--- a/src/AdjListHyperGraph.chpl
+++ b/src/AdjListHyperGraph.chpl
@@ -891,7 +891,7 @@ module AdjListHyperGraph {
       
       this._vPropType = vPropType;
       this._ePropType = ePropType;
-      this._destBuffer = new Aggregator((vIndexType, eIndexType, InclusionType));
+      this._destBuffer = new Aggregator((vIndexType, eIndexType, InclusionType), 64 * 1024);
       this._vPropMap = vPropMap;
       this._ePropMap = ePropMap;
 

--- a/src/CHGL.chpl
+++ b/src/CHGL.chpl
@@ -13,3 +13,4 @@ use AggregationBuffer;
 use DynamicAggregationBuffer;
 use UnrolledLinkedList;
 use Privatization;
+use ExplicitString;

--- a/src/DynamicAggregationBuffer.chpl
+++ b/src/DynamicAggregationBuffer.chpl
@@ -106,7 +106,7 @@ module DynamicAggregationBuffer {
 
     proc init(type msgType) {
       this.msgType = msgType;
-      this.agg = new Aggregator(msgType);
+      this.agg = new Aggregator(msgType, 8 * 1024);
       complete();
 
       this.pid = _newPrivatizedClass(_to_unmanaged(this));

--- a/src/ExplicitString.chpl
+++ b/src/ExplicitString.chpl
@@ -1,0 +1,80 @@
+/*
+    Due to behavior of `_string` (Chapel's native string type) that:
+
+        1) Creates a full on copy of the string on assignment even if it is not needed.
+            https://github.com/chapel-lang/chapel/blob/e6b8fd15b54e2c1f04d4dbf5bc8bff523551842a/modules/internal/String.chpl#L2018-L2029
+        2) Leaks the implicit string copy if stored in a Chapel array that never shrinks
+        3) Naively rehashes the string and does not cache the hash, hence resulting in excess implicit copies and remote transfers
+
+    These issues have also been confirmed by Michael Ferguson (@mppf); hence to get around this, this module features
+    a new 'String' type that does not create any implicit copies. This is necessary not only for performance but also
+    space overhead.
+*/
+
+record String {
+    // String
+    var data : _ddata(uint(8));
+    // Length of string
+    var dataLen : int(64);
+    // Precomputed Hash
+    var hash : uint(64);
+
+    proc init() {
+        this.data = nil;
+        this.hash = chpl__defaultHash("");
+    }
+
+    proc init=(other : String) {
+        this.data = other.data;
+        this.dataLen = other.dataLen;
+        this.hash = other.hash;
+    }
+
+    proc init(str : string) {
+        // TODO: Once on master, set `initElts=false`
+        this.data = _ddata_allocate(uint(8), str.size);
+        this.dataLen = str.size;
+        c_memcpy((this.data:c_void_ptr):c_ptr(uint(8)), str.localize().buff, str.size);
+        this.hash = chpl__defaultHash(str);
+    }
+
+    // Convert into a string; this string does not own nor does it copy the data, meaning modifications to it effects 'String'
+    proc toString() {
+        if this.dataLen == 0 then return "";
+        if data.locale == here {
+            return new string((this.data:c_void_ptr):c_string, dataLen, isowned=false, needToCopy=false);
+        } else {
+            var ret : string;
+            on data do ret = new string((this.data:c_void_ptr):c_string, dataLen, isowned=false, needToCopy=false);
+            return ret.localize(); 
+        }
+    }
+
+    proc readWriteThis(f) { f <~> "(String) { data = " <~> this.toString() <~> ", dataLen = " <~> dataLen <~> ", hash = " <~> hash <~> " }"; }
+
+    proc destroy() {
+        _ddata_free(data, dataLen);
+    }
+}
+
+proc +(str1 : string, str2 : String) : string {
+    return str1 + str2.toString();
+}
+
+proc +(str1 : String, str2 : String) : string {
+    return str1.toString() + str2.toString();
+}
+
+proc +(str1 : String, str2 : string) : string {
+    return str1.toString() + str2;
+}
+
+proc ==(str1 : String, str2 : String) : bool {
+    return str1.hash == str2.hash && str1.dataLen == str2.dataLen && (str1.data == str2.data || str1.toString() == str2.toString());
+}
+
+pragma "no doc"
+inline proc chpl__defaultHash(str : String): uint {
+    if str.hash == 0 then halt("Attempt to hash an empty 'String'");
+    return str.hash;
+}

--- a/src/Graph.chpl
+++ b/src/Graph.chpl
@@ -94,7 +94,7 @@ module Graph {
       edgeCounter = new unmanaged Centralized(atomic int);
       this.vDescType = hg.vDescType;
       if CHPL_NETWORK_ATOMICS == "none" {
-        insertAggregator = new Aggregator((hg.vDescType, hg.vDescType, int));
+        insertAggregator = new Aggregator((hg.vDescType, hg.vDescType, int), 64 * 1024);
       }
       this.cachedNeighborListDom = hg.verticesDomain;
       complete();

--- a/src/Metrics.chpl
+++ b/src/Metrics.chpl
@@ -113,7 +113,7 @@ module Metrics {
   proc getVertexComponentMappings(graph, s = 1) {
     var components : [graph.verticesDomain] atomic int;
     var componentId : atomic int;
-    var workQueue = new WorkQueue((int,int), 1024 * 1024, new ComponentCoalescer());
+    var workQueue = new WorkQueue((int,int), 8 * 1024, new ComponentCoalescer());
     var terminationDetector = new TerminationDetector();
 
     // Begin at 1 so 0 becomes 'not visited' sentinel value
@@ -191,7 +191,7 @@ module Metrics {
   proc getEdgeComponentMappings(graph, s = 1) {
     var components : [graph.edgesDomain] atomic int;
     var componentId : atomic int;
-    var workQueue = new WorkQueue((int,int), 1024 * 1024, new ComponentCoalescer());
+    var workQueue = new WorkQueue((int,int), 8 * 1024, new ComponentCoalescer());
     var terminationDetector = new TerminationDetector();
 
     // Begin at 1 so 0 becomes 'not visited' sentinel value

--- a/src/Privatization.chpl
+++ b/src/Privatization.chpl
@@ -90,11 +90,11 @@ class PrivatizedImpl {
   proc dsiGetPrivatizeData() { return (this.privatizedArray, this.pid); }
   proc readWriteThis(f) { f <~> broadcast[here.id]; }
 
-  proc onLocale(loc : locale) ref {
-    return onLocale(loc.id);
+  proc get(loc : locale = here) ref {
+    return get(loc.id);
   }
 
-  proc onLocale(locid : int) ref {
+  proc get(locid : int) ref {
     return broadcast[locid];
   }
 

--- a/src/Traversal.chpl
+++ b/src/Traversal.chpl
@@ -25,7 +25,7 @@ iter vertexBFS(graph, v : graph._value.vDescType, s=1) : graph._value.vDescType 
 iter vertexBFS(graph, v : graph._value.vDescType, s=1, param tag : iterKind) : graph._value.vDescType where tag == iterKind.standalone {
   var visited : [graph.verticesDomain] atomic bool;
   var td = new TerminationDetector(1);
-  var wq = new WorkQueue(int, 1024 * 1024, new DuplicateCoalescer(int, -1));
+  var wq = new WorkQueue(int, 1024, new DuplicateCoalescer(int, -1));
   wq.addWork(v.id, graph.getLocale(v));
   forall v in doWorkLoop(wq, td) {
     if v != -1 && visited[v].testAndSet() == false {
@@ -59,7 +59,7 @@ iter edgeBFS(graph, e : graph._value.eDescType, s=1) : graph._value.eDescType {
 iter edgeBFS(graph, e : graph._value.eDescType, s=1, param tag : iterKind) : graph._value.eDescType where tag == iterKind.standalone {  
   var visited : [graph.edgesDomain] atomic bool;
   var td = new TerminationDetector(1);
-  var wq = new WorkQueue(int, 1024 * 1024, new DuplicateCoalescer(int, -1));
+  var wq = new WorkQueue(int, 1024, new DuplicateCoalescer(int, -1));
   wq.addWork(e.id, graph.getLocale(e));
   forall e in doWorkLoop(wq, td) {
     if e != -1 && visited[e].testAndSet() == false {

--- a/src/Traversal.chpl
+++ b/src/Traversal.chpl
@@ -27,7 +27,8 @@ iter vertexBFS(graph, v : graph._value.vDescType, s=1, param tag : iterKind) : g
   var td = new TerminationDetector(1);
   var wq = new WorkQueue(int, 1024, new DuplicateCoalescer(int, -1));
   wq.addWork(v.id, graph.getLocale(v));
-  forall v in doWorkLoop(wq, td) {
+  // Heuristic: If the vertex has a _massive_ number of neighbors, 
+  forall v in doWorkLoop(wq, td, tasks=1..1) {
     if v != -1 && visited[v].testAndSet() == false {
       yield graph.toVertex(v);
       forall vv in graph.walk(graph.toVertex(v), s=1, isImmutable=true) {
@@ -41,7 +42,7 @@ iter vertexBFS(graph, v : graph._value.vDescType, s=1, param tag : iterKind) : g
   wq.destroy();
 }
 
-iter edgeBFS(graph, e : graph._value.eDescType, s=1) : graph._value.eDescType {
+iter edgeBFS(graph, e : graph._value.eDescType, s=1, useMaximumParallelism = false) : graph._value.eDescType {
   var explored : domain(int);
   var queue = new UnrolledLinkedList(int, 1024);
   queue.append(e.id);
@@ -56,12 +57,12 @@ iter edgeBFS(graph, e : graph._value.eDescType, s=1) : graph._value.eDescType {
   }
 }
 
-iter edgeBFS(graph, e : graph._value.eDescType, s=1, param tag : iterKind) : graph._value.eDescType where tag == iterKind.standalone {  
+iter edgeBFS(graph, e : graph._value.eDescType, s=1, useMaximumParallelism = false, param tag : iterKind) : graph._value.eDescType where tag == iterKind.standalone {  
   var visited : [graph.edgesDomain] atomic bool;
   var td = new TerminationDetector(1);
-  var wq = new WorkQueue(int, 1024, new DuplicateCoalescer(int, -1));
+  var wq = new WorkQueue(int, if useMaximumParallelism then 64 * 1024 else 1024, new DuplicateCoalescer(int, -1));
   wq.addWork(e.id, graph.getLocale(e));
-  forall e in doWorkLoop(wq, td) {
+  forall e in doWorkLoop(wq, td, tasks= if useMaximumParallelism then 1..here.maxTaskPar else 1..1) {
     if e != -1 && visited[e].testAndSet() == false {
       yield graph.toEdge(e);
       forall ee in graph.walk(graph.toEdge(e), s=1, isImmutable=true) {

--- a/test/Privatized.chpl
+++ b/test/Privatized.chpl
@@ -31,7 +31,7 @@ coforall loc in Locales do on loc {
 }
 
 keepAlive.write(true);
-keepAlive.onLocale(numLocales - 1).write(true);
+keepAlive.get(numLocales - 1).write(true);
 coforall loc in Locales do on loc {
     writeln(keepAlive.broadcast);
 }

--- a/test_performance/BFS-Naive.chpl
+++ b/test_performance/BFS-Naive.chpl
@@ -86,8 +86,8 @@ writeln("Initialization in ", timer.elapsed(), "s");
 timer.clear();
 
 beginProfile("BFS-Naive-Perf");
-var current = new WorkQueue(int, 1024 * 1024, new DuplicateCoalescer(int, -1));
-var next = new WorkQueue(int, 1024 * 1024, new DuplicateCoalescer(int, -1));
+var current = new WorkQueue(int, 64 * 1024, new DuplicateCoalescer(int, -1));
+var next = new WorkQueue(int, 64 * 1024, new DuplicateCoalescer(int, -1));
 var currTD = new TerminationDetector(1);
 var nextTD = new TerminationDetector(0);
 current.addWork(0, vertices[0].locale);

--- a/test_performance/Privatized.chpl
+++ b/test_performance/Privatized.chpl
@@ -61,7 +61,7 @@ timer.start();
 coforall loc in Locales do on loc {
     coforall tid in 1..here.maxTaskPar {
         for i in 1..N {
-            privatizedAtomic.onLocale(i % numLocales).add(1);
+            privatizedAtomic.get(i % numLocales).add(1);
         }
     }
 }
@@ -73,7 +73,7 @@ timer.start();
 coforall loc in Locales do on loc {
     coforall tid in 1..here.maxTaskPar {
         for i in 1..N {
-            privatizedInteger.onLocale(i % numLocales) = 1;
+            privatizedInteger.get(i % numLocales) = 1;
         }
     }
 }


### PR DESCRIPTION
- Reduces memory used by aggregation buffers down to a reasonable size of 64K (sometimes as low as 8K and 1K) which solved the OOM issues I was having on Swan (Cray Aries)
- Added ability to specify locales to distribute the work over as well as the number of tasks spawned per locale.
- Added experimental new `ExplicitString` to avoid explicit copies and leaked strings; not yet used.